### PR TITLE
[feat/#4] response 형식 통일 (에러도 포함)

### DIFF
--- a/src/main/java/com/example/techere/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/techere/domain/group/controller/GroupController.java
@@ -1,0 +1,32 @@
+package com.example.techere.domain.group.controller;
+
+import com.example.techere.global.error.ErrorCode;
+import com.example.techere.global.error.exception.BusinessException;
+import com.example.techere.global.result.ResultCode;
+import com.example.techere.global.result.ResultResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/groups")
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GroupController {
+
+    @PostMapping
+    public ResponseEntity<ResultResponse> create(@PathVariable int isValid) {
+
+        // Validation 처리
+        if (isValid == 0) {
+            // Validation을 통과하지 못할 경우 Exception을 반환
+            // exception occurs
+            throw new BusinessException(ErrorCode.INPUT_INVALID_VALUE, "Reason why it isn't valid");
+        }
+
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GROUP_CREATE_SUCCESS));
+    }
+}

--- a/src/main/java/com/example/techere/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/techere/domain/group/controller/GroupController.java
@@ -17,13 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class GroupController {
 
-    @PostMapping
+    @PostMapping("/{isValid}")
     public ResponseEntity<ResultResponse> create(@PathVariable int isValid) {
 
-        // Validation 처리
         if (isValid == 0) {
-            // Validation을 통과하지 못할 경우 Exception을 반환
-            // exception occurs
             throw new BusinessException(ErrorCode.INPUT_INVALID_VALUE, "Reason why it isn't valid");
         }
 

--- a/src/main/java/com/example/techere/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/techere/domain/group/controller/GroupController.java
@@ -17,13 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class GroupController {
 
-    @PostMapping("/{isValid}")
-    public ResponseEntity<ResultResponse> create(@PathVariable int isValid) {
+  @PostMapping("/{isValid}")
+  public ResponseEntity<ResultResponse> create(@PathVariable int isValid) {
 
-        if (isValid == 0) {
-            throw new BusinessException(ErrorCode.INPUT_INVALID_VALUE, "Reason why it isn't valid");
-        }
-
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GROUP_CREATE_SUCCESS));
+    if (isValid == 0) {
+      throw new BusinessException(ErrorCode.INPUT_INVALID_VALUE, "Reason why it isn't valid");
     }
+
+    return ResponseEntity.ok(ResultResponse.of(ResultCode.GROUP_CREATE_SUCCESS));
+  }
 }

--- a/src/main/java/com/example/techere/global/error/ErrorCode.java
+++ b/src/main/java/com/example/techere/global/error/ErrorCode.java
@@ -1,11 +1,10 @@
 package com.example.techere.global.error;
 
+import java.util.Optional;
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-
-import java.util.Optional;
-import java.util.function.Predicate;
 
 /** {주체}_{이유} message 는 동사 명사형으로 마무리 */
 @Getter
@@ -31,13 +30,12 @@ public enum ErrorCode {
 
   public String getMessage(String message) {
     return Optional.ofNullable(message)
-            .filter(Predicate.not(String::isBlank))
-            .orElse(this.getMessage());
+        .filter(Predicate.not(String::isBlank))
+        .orElse(this.getMessage());
   }
 
   @Override
   public String toString() {
     return String.format("%s (%d)", this.name(), this.getCode());
   }
-
 }

--- a/src/main/java/com/example/techere/global/error/ErrorCode.java
+++ b/src/main/java/com/example/techere/global/error/ErrorCode.java
@@ -1,22 +1,43 @@
 package com.example.techere.global.error;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+import java.util.function.Predicate;
 
 /** {주체}_{이유} message 는 동사 명사형으로 마무리 */
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public enum ErrorCode {
   // Global
-  INTERNAL_SERVER_ERROR(500, "G001", "서버 오류"),
-  INPUT_INVALID_VALUE(400, "G002", "잘못된 입력"),
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E001", "서버 오류"),
+  INPUT_INVALID_VALUE(HttpStatus.BAD_REQUEST, "E002", "잘못된 입력"),
 
   // 예시
   // User 도메인
-  EXAMPLE_USER_ERROR(400, "U001", "테스트용 예시 에러코드"),
+  EXAMPLE_USER_ERROR(HttpStatus.BAD_REQUEST, "U001", "테스트용 예시 에러코드"),
   ;
 
-  private final int status;
+  private final HttpStatus status;
   private final String code;
   private final String message;
+
+  public String getMessage(Throwable e) {
+    return this.getMessage(this.getMessage() + " - " + e.getMessage());
+    // 결과 예시 - "Validation error - Reason why it isn't valid"
+  }
+
+  public String getMessage(String message) {
+    return Optional.ofNullable(message)
+            .filter(Predicate.not(String::isBlank))
+            .orElse(this.getMessage());
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s (%d)", this.name(), this.getCode());
+  }
+
 }

--- a/src/main/java/com/example/techere/global/error/ErrorResponse.java
+++ b/src/main/java/com/example/techere/global/error/ErrorResponse.java
@@ -1,14 +1,13 @@
 package com.example.techere.global.error;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.validation.BindingResult;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Builder
 @Getter

--- a/src/main/java/com/example/techere/global/error/ErrorResponse.java
+++ b/src/main/java/com/example/techere/global/error/ErrorResponse.java
@@ -1,28 +1,32 @@
 package com.example.techere.global.error;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.*;
-import org.springframework.validation.BindingResult;
 
 @Builder
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse {
-  private String businessCode;
-  private String errorMessage;
+  private String code;
+  private String message;
   private List<FieldError> errors;
 
   private ErrorResponse(ErrorCode code, List<FieldError> fieldErrors) {
-    this.businessCode = code.getCode();
-    this.errorMessage = code.getMessage();
+    this.code = code.getCode();
+    this.message = code.getMessage();
     this.errors = fieldErrors;
   }
 
   private ErrorResponse(ErrorCode code) {
-    this.businessCode = code.getCode();
-    this.errorMessage = code.getMessage();
+    this.code = code.getCode();
+    this.message = code.getMessage();
     this.errors = new ArrayList<>();
   }
 

--- a/src/main/java/com/example/techere/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/techere/global/error/GlobalExceptionHandler.java
@@ -16,30 +16,30 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @RestControllerAdvice(annotations = {RestController.class})
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-  @ExceptionHandler
-  public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
-    return handleExceptionInternal(e, ErrorCode.INPUT_INVALID_VALUE, request);
-  }
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        return handleExceptionInternal(e, ErrorCode.INPUT_INVALID_VALUE, request);
+    }
 
-  @ExceptionHandler
-  public ResponseEntity<Object> business(BusinessException e, WebRequest request) {
-    return handleExceptionInternal(e, e.getErrorCode(), request);
-  }
+    @ExceptionHandler
+    public ResponseEntity<Object> business(BusinessException e, WebRequest request) {
+        return handleExceptionInternal(e, e.getErrorCode(), request);
+    }
 
-  @ExceptionHandler
-  public ResponseEntity<Object> exception(Exception e, WebRequest request) {
-    return handleExceptionInternal(e, ErrorCode.INTERNAL_SERVER_ERROR, request);
-  }
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        return handleExceptionInternal(e, ErrorCode.INTERNAL_SERVER_ERROR, request);
+    }
 
-  private ResponseEntity<Object> handleExceptionInternal(
-      Exception e, ErrorCode errorCode, WebRequest request) {
-    log.error(e.getMessage(), e);
-    return handleExceptionInternal(e, errorCode, errorCode.getStatus(), request);
-  }
+    private ResponseEntity<Object> handleExceptionInternal(
+            Exception e, ErrorCode errorCode, WebRequest request) {
+        log.error(e.getMessage(), e);
+        return handleExceptionInternal(e, errorCode, errorCode.getStatus(), request);
+    }
 
-  private ResponseEntity<Object> handleExceptionInternal(
-      Exception e, ErrorCode errorCode, HttpStatus status, WebRequest request) {
-    return super.handleExceptionInternal(
-        e, ErrorResponse.of(errorCode), HttpHeaders.EMPTY, status, request);
-  }
+    private ResponseEntity<Object> handleExceptionInternal(
+            Exception e, ErrorCode errorCode, HttpStatus status, WebRequest request) {
+        return super.handleExceptionInternal(
+                e, ErrorResponse.of(errorCode), HttpHeaders.EMPTY, status, request);
+    }
 }

--- a/src/main/java/com/example/techere/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/techere/global/error/GlobalExceptionHandler.java
@@ -31,22 +31,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     return handleExceptionInternal(e, ErrorCode.INTERNAL_SERVER_ERROR, request);
   }
 
-
-  private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorCode errorCode,
-                                                         WebRequest request) {
+  private ResponseEntity<Object> handleExceptionInternal(
+      Exception e, ErrorCode errorCode, WebRequest request) {
     log.error(e.getMessage(), e);
-    return handleExceptionInternal(e, errorCode, errorCode.getStatus(),
-            request);
+    return handleExceptionInternal(e, errorCode, errorCode.getStatus(), request);
   }
 
-  private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorCode errorCode,
-                                                         HttpStatus status, WebRequest request) {
+  private ResponseEntity<Object> handleExceptionInternal(
+      Exception e, ErrorCode errorCode, HttpStatus status, WebRequest request) {
     return super.handleExceptionInternal(
-            e,
-            ErrorResponse.of(errorCode),
-            HttpHeaders.EMPTY,
-            status,
-            request
-    );
+        e, ErrorResponse.of(errorCode), HttpHeaders.EMPTY, status, request);
   }
 }

--- a/src/main/java/com/example/techere/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/techere/global/error/GlobalExceptionHandler.java
@@ -16,30 +16,30 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @RestControllerAdvice(annotations = {RestController.class})
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    @ExceptionHandler
-    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
-        return handleExceptionInternal(e, ErrorCode.INPUT_INVALID_VALUE, request);
-    }
+  @ExceptionHandler
+  public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+    return handleExceptionInternal(e, ErrorCode.INPUT_INVALID_VALUE, request);
+  }
 
-    @ExceptionHandler
-    public ResponseEntity<Object> business(BusinessException e, WebRequest request) {
-        return handleExceptionInternal(e, e.getErrorCode(), request);
-    }
+  @ExceptionHandler
+  public ResponseEntity<Object> business(BusinessException e, WebRequest request) {
+    return handleExceptionInternal(e, e.getErrorCode(), request);
+  }
 
-    @ExceptionHandler
-    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
-        return handleExceptionInternal(e, ErrorCode.INTERNAL_SERVER_ERROR, request);
-    }
+  @ExceptionHandler
+  public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+    return handleExceptionInternal(e, ErrorCode.INTERNAL_SERVER_ERROR, request);
+  }
 
-    private ResponseEntity<Object> handleExceptionInternal(
-            Exception e, ErrorCode errorCode, WebRequest request) {
-        log.error(e.getMessage(), e);
-        return handleExceptionInternal(e, errorCode, errorCode.getStatus(), request);
-    }
+  private ResponseEntity<Object> handleExceptionInternal(
+      Exception e, ErrorCode errorCode, WebRequest request) {
+    log.error(e.getMessage(), e);
+    return handleExceptionInternal(e, errorCode, errorCode.getStatus(), request);
+  }
 
-    private ResponseEntity<Object> handleExceptionInternal(
-            Exception e, ErrorCode errorCode, HttpStatus status, WebRequest request) {
-        return super.handleExceptionInternal(
-                e, ErrorResponse.of(errorCode), HttpHeaders.EMPTY, status, request);
-    }
+  private ResponseEntity<Object> handleExceptionInternal(
+      Exception e, ErrorCode errorCode, HttpStatus status, WebRequest request) {
+    return super.handleExceptionInternal(
+        e, ErrorResponse.of(errorCode), HttpHeaders.EMPTY, status, request);
+  }
 }

--- a/src/main/java/com/example/techere/global/error/exception/BusinessException.java
+++ b/src/main/java/com/example/techere/global/error/exception/BusinessException.java
@@ -7,8 +7,28 @@ import lombok.Getter;
 public class BusinessException extends RuntimeException {
   private final ErrorCode errorCode;
 
+  public BusinessException() {
+    super(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+    this.errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+  }
+
+  public BusinessException(String message) {
+    super(ErrorCode.INTERNAL_SERVER_ERROR.getMessage(message));
+    this.errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+  }
+
+  public BusinessException(String message, Throwable cause) {
+    super(ErrorCode.INTERNAL_SERVER_ERROR.getMessage(message), cause);
+    this.errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+  }
+
   public BusinessException(ErrorCode errorCode) {
     super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public BusinessException(ErrorCode errorCode, String message) {
+    super(errorCode.getMessage(message));
     this.errorCode = errorCode;
   }
 }

--- a/src/main/java/com/example/techere/global/result/ResultCode.java
+++ b/src/main/java/com/example/techere/global/result/ResultCode.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 public enum ResultCode {
 
   // 도메인 별로 나눠서 관리(ex: User 도메인)
-  // user
-  USER_CREATE_SUCCESS("U001", "사용자 생성 성공"),
+  // group
+  GROUP_CREATE_SUCCESS("G001", "그룹 생성 성공"),
   ;
 
   private final String code;

--- a/src/main/java/com/example/techere/global/result/ResultResponse.java
+++ b/src/main/java/com/example/techere/global/result/ResultResponse.java
@@ -13,6 +13,11 @@ public class ResultResponse {
     return new ResultResponse(resultCode, data);
   }
 
+  public static ResultResponse of(ResultCode resultCode) {
+    return new ResultResponse(resultCode, "");
+  }
+
+
   public ResultResponse(ResultCode resultCode, Object data) {
     this.code = resultCode.getCode();
     this.message = resultCode.getMessage();

--- a/src/main/java/com/example/techere/global/result/ResultResponse.java
+++ b/src/main/java/com/example/techere/global/result/ResultResponse.java
@@ -17,7 +17,6 @@ public class ResultResponse {
     return new ResultResponse(resultCode, "");
   }
 
-
   public ResultResponse(ResultCode resultCode, Object data) {
     this.code = resultCode.getCode();
     this.message = resultCode.getMessage();


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 기존에 있던 GlobalExceptionHandler의 return 값을 response body -> response 전체(헤더도 포함할 수 있도록 변경)
- ResultResponse의 변수명과 ErrorResponse 변수명 통일
- 어떻게 사용하는 지 간단한 예시 코드 추가(GroupController.java)
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [x] 추가/수정사항을 설명하였는가?